### PR TITLE
fix: set headers to enhance security

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,35 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async headers() {
+		return [
+			{
+				source: '/(.*)',
+				headers: [
+					{
+						key: 'Strict-Transport-Security',
+						value: 'max-age=31536000; includeSubDomains; preload'
+					},
+					{
+						key: 'Content-Security-Policy',
+						value: "frame-ancestors 'self' https://useautumn.com/;"
+					},
+					{
+						key: 'X-Frame-Options',
+						value: 'SAMEORIGIN'
+					},
+					{
+						key: 'Referrer-Policy',
+						value: 'origin-when-cross-origin'
+					},
+					{
+						key: 'X-Content-Type-Options',
+						value: 'nosniff'
+					}
+				]
+			}
+		]
+	},
 
   // This is required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,


### PR DESCRIPTION
These headers are used to make sure its only accessed using https and to prevent clickhjacking when embedded as an iframe.